### PR TITLE
Add missing 'var's.

### DIFF
--- a/Jenkins.js
+++ b/Jenkins.js
@@ -72,7 +72,7 @@ function lookup3(k, pc, pb) {
         c += k.charCodeAt(offset + 10) << 16;
         c += k.charCodeAt(offset + 11) << 24;
 
-        mixed = mix(a, b, c);
+        var mixed = mix(a, b, c);
         a = mixed.a;
         b = mixed.b;
         c = mixed.c;

--- a/SimHash.js
+++ b/SimHash.js
@@ -71,7 +71,7 @@ function combineShingles(shingles) {
     for (var pos = 0; pos < 32; pos++) {
         var weight = 0;
         for (var i in shingles) {
-            shingle = parseInt(shingles[i], 16);
+            var shingle = parseInt(shingles[i], 16);
             weight += !(~shingle & mask) == 1 ? 1 : -1;
         }
         if (weight > 0) simhash |= mask;

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
-Jenkins = require('./Jenkins.js').Jenkins;
-SimHash = require('./SimHash.js').SimHash;
-Comparator = require('./Comparator.js').Comparator;
+var Jenkins = require('./Jenkins.js').Jenkins;
+var SimHash = require('./SimHash.js').SimHash;
+var Comparator = require('./Comparator.js').Comparator;
 
 
 module.exports.Jenkins = Jenkins;


### PR DESCRIPTION
This fixes JS issues when we use strict mode in TypeScript compilerOptions.